### PR TITLE
Possible fix to limbo state

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -221,6 +221,10 @@ public class GameManager : MonoBehaviour
                 StartCoroutine(GameEnd(s_defender.team));
         }
 
+        //when a secondary game ends, and white wins, black does not automatically move a random piece, and so the game is stuck in limbo
+        //not sure how you would fix this but maybe just try
+        //comp.MoveRandomPiece();
+
         current_player = PieceTeam.White;
         state = GameState.WhiteTurn;
         playing_main = true;


### PR DESCRIPTION
Since you don't have issues, I'm just gonna make this pull request to tell you about a bug. Basically when you go in the secondary game, and white wins, the game just gets stuck in limbo because you haven't called comp.MoveRandomPiece(); and so black doesn't randomly move a piece. Should be able to fix by just adding that line after the secondary game is won. 